### PR TITLE
Change navbar justification

### DIFF
--- a/style.css
+++ b/style.css
@@ -111,7 +111,7 @@ nav {
 
 nav ul {
 display: flex ;
-justify-content: space-around;
+justify-content: center;
 padding: 0;
 margin: 0;
 
@@ -197,8 +197,16 @@ form {
 
   form {
     max-width: 450px;
+  }
 }
 
+
+@media only screen and (min-width: 650px )  {
+
+  .navbar__li {
+      font-size: 1rem;
+      padding: 1rem 2.4rem;
+  }
 }
 
 .clearfix {


### PR DESCRIPTION
navbar now center justified
min-width 650px created to prevent 'about us' nav element from twolining on smaller screens.
Requires 650px, not 600px